### PR TITLE
Path based branch name fix seperator

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,40 +49,25 @@ _For more introduction, please refer to the [How it works](#how-it-works)._
 
 - [Introduction](#introduction)
   - [Features](#features)
-- [Table of Contents](#table-of-contents)
 - [Getting Started](#getting-started)
   - [Prerequisites](#prerequisites)
   - [Installation](#installation)
   - [Quick Start](#quick-start)
-    - [Options](#options)
 - [Recipes](#recipes)
   - [GitHub Repo Templates](#github-repo-templates)
-    - [Use Custom templates](#use-custom-templates)
   - [Local Templates](#local-templates)
   - [Remote ZIP Templates](#remote-zip-templates)
   - [Offline Mode](#offline-mode)
-  - [Prompts Override](#prompts-override)
-  - [Debug Mode](#debug-mode)
   - [List Available Templates](#list-available-templates)
-    - [Arguments](#arguments)
-    - [Options](#options-1)
   - [Official Templates](#official-templates)
 - [Advanced](#advanced)
   - [Create Your Template](#create-your-template)
   - [Configuration](#configuration)
   - [Create Your Scaffold](#create-your-scaffold)
 - [References](#references)
-  - [caz(template, project?, options?)](#caztemplate-project-options)
-    - [template](#template)
-    - [project](#project)
-    - [options](#options-2)
-      - [force](#force)
-      - [offline](#offline)
-      - [[key: string]](#key-string)
 - [Motivation](#motivation)
 - [About](#about)
   - [How It Works](#how-it-works)
-    - [Main Workflow](#main-workflow)
   - [Built With](#built-with)
 - [Roadmap](#roadmap)
 - [Contributing](#contributing)
@@ -156,17 +141,6 @@ $ caz zce/nm my-project
 The above command pulls the template from [zce/nm](https://github.com/zce/nm). This means that you can also pull templates from your public GitHub repository.
 
 **Public repository is necessary.**
-
-> You can also get your template from branches defined inside your public repositories. Use the `:` separator as follows:
-> ```shell
-> $ caz zce/nm:<branch-name> my-project
-> ```
->  
-> e.g.
-> ```shell
-> $ caz zce/nm:category1/name my-project
-> ``` 
-> The command above will pull the template from the branch `category1/name` of the public repo `zce/nm`.
 
 ### Local Templates
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ $ caz nm my-project
 The above command pulls the template from [caz-templates/nm](https://github.com/caz-templates/nm), then prompts for some information according to the configuration of this template, and generate the project at `./my-project`.
 
 ```shell
-$ caz nm#typescript my-project
+$ caz nm:typescript my-project
 ```
 
 By running this command, CAZ will pulls the template from `typescript` branch of [caz-templates/nm](https://github.com/caz-templates/nm).

--- a/README.md
+++ b/README.md
@@ -49,25 +49,40 @@ _For more introduction, please refer to the [How it works](#how-it-works)._
 
 - [Introduction](#introduction)
   - [Features](#features)
+- [Table of Contents](#table-of-contents)
 - [Getting Started](#getting-started)
   - [Prerequisites](#prerequisites)
   - [Installation](#installation)
   - [Quick Start](#quick-start)
+    - [Options](#options)
 - [Recipes](#recipes)
   - [GitHub Repo Templates](#github-repo-templates)
+    - [Use Custom templates](#use-custom-templates)
   - [Local Templates](#local-templates)
   - [Remote ZIP Templates](#remote-zip-templates)
   - [Offline Mode](#offline-mode)
+  - [Prompts Override](#prompts-override)
+  - [Debug Mode](#debug-mode)
   - [List Available Templates](#list-available-templates)
+    - [Arguments](#arguments)
+    - [Options](#options-1)
   - [Official Templates](#official-templates)
 - [Advanced](#advanced)
   - [Create Your Template](#create-your-template)
   - [Configuration](#configuration)
   - [Create Your Scaffold](#create-your-scaffold)
 - [References](#references)
+  - [caz(template, project?, options?)](#caztemplate-project-options)
+    - [template](#template)
+    - [project](#project)
+    - [options](#options-2)
+      - [force](#force)
+      - [offline](#offline)
+      - [[key: string]](#key-string)
 - [Motivation](#motivation)
 - [About](#about)
   - [How It Works](#how-it-works)
+    - [Main Workflow](#main-workflow)
   - [Built With](#built-with)
 - [Roadmap](#roadmap)
 - [Contributing](#contributing)
@@ -141,6 +156,17 @@ $ caz zce/nm my-project
 The above command pulls the template from [zce/nm](https://github.com/zce/nm). This means that you can also pull templates from your public GitHub repository.
 
 **Public repository is necessary.**
+
+> You can also get your template from branches defined inside your public repositories. Use the `:` separator as follows:
+> ```shell
+> $ caz zce/nm:<branch-name> my-project
+> ```
+>  
+> e.g.
+> ```shell
+> $ caz zce/nm:category1/name my-project
+> ``` 
+> The command above will pull the template from the branch `category1/name` of the public repo `zce/nm`.
 
 ### Local Templates
 

--- a/src/init/resolve.ts
+++ b/src/init/resolve.ts
@@ -34,7 +34,7 @@ export const getTemplatePath = async (input: string): Promise<false | string> =>
 export const getTemplateUrl = async (input: string): Promise<string> => {
   if (/^https?:/.test(input)) return input
 
-  const [fullname, maybeBranch] = input.split('#')
+  const [fullname, maybeBranch] = input.split(':')
   const [maybeOwner, maybeName] = fullname.split('/')
 
   const isEmpty = (input?: string): boolean => input == null || input === ''

--- a/test/init/resolve.spec.ts
+++ b/test/init/resolve.spec.ts
@@ -47,19 +47,19 @@ test('unit:init:resolve:getTemplateUrl', async () => {
   const url2 = await getTemplateUrl('zce/tpl2')
   expect(url2).toBe('https://github.com/zce/tpl2/archive/refs/heads/master.zip')
 
-  const url3 = await getTemplateUrl('zce/tpl3#dev')
+  const url3 = await getTemplateUrl('zce/tpl3:dev')
   expect(url3).toBe('https://github.com/zce/tpl3/archive/refs/heads/dev.zip')
 
-  const url4 = await getTemplateUrl('tpl4#dev')
+  const url4 = await getTemplateUrl('tpl4:dev')
   expect(url4).toBe('https://github.com/caz-templates/tpl4/archive/refs/heads/dev.zip')
 
   const url5 = await getTemplateUrl('https://github.com/zce/tpl5/archive/refs/heads/dev.zip')
   expect(url5).toBe('https://github.com/zce/tpl5/archive/refs/heads/dev.zip')
 
-  const url6 = await getTemplateUrl('zce/tpl3#dev/cli')
+  const url6 = await getTemplateUrl('zce/tpl3:dev/cli')
   expect(url6).toBe('https://github.com/zce/tpl3/archive/refs/heads/dev/cli.zip')
 
-  const url7 = await getTemplateUrl('tpl7#topic/xyz')
+  const url7 = await getTemplateUrl('tpl7:topic/xyz')
   expect(url7).toBe('https://github.com/caz-templates/tpl7/archive/refs/heads/topic/xyz.zip')
 })
 


### PR DESCRIPTION
I looks like using `#` as a separator between the repo name and the branch name was a bad idea. In `bash`, the `#` sign is considered as the beginning of a line comment. So, I it is better to use `:` (colon) as a separator. 
 